### PR TITLE
prevent adding test files to git repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ProfessorHomeDirectory
 *.pyc
 omsi_answer*
+SuppFile
+ExamQuestions.txt


### PR DESCRIPTION
Each time the student downloads a test, `ExamQuestions.txt` and `SuppFile` may have new data, which should not be committed into the git repository (same for `omsi_answer1.txt`, ...)